### PR TITLE
feat: add config.middleware/extension deps order

### DIFF
--- a/lib/application.js
+++ b/lib/application.js
@@ -32,7 +32,7 @@ class Application extends BaseApp {
   init(frameworkConfig, frameworkOptions, appConfig, envConfig) {
     // console.log(typeof this.__proto__.__proto__.init);
     super.init(frameworkConfig, frameworkOptions, appConfig, envConfig);
-    //this.__proto__.__proto__.init.call(this, frameworkConfig, frameworkOptions, appConfig, envConfig);
+    // this.__proto__.__proto__.init.call(this, frameworkConfig, frameworkOptions, appConfig, envConfig);
     /**
      * 初始化express
      */
@@ -167,7 +167,7 @@ class Application extends BaseApp {
         code = utils.code[err] || 'ERROR';
         message = code;
         httpCode = err;
-      } else /*if (typeof err === 'string')*/ {
+      } else /* if (typeof err === 'string')*/ {
         code = 'ERROR';
         message = err;
         httpCode = utils.map[String(message).toUpperCase()] || defaultHttpErrorCode;
@@ -193,7 +193,7 @@ class Application extends BaseApp {
           }
           res.jsonp(err);
         } else {
-          switch(mime) {
+          switch (mime) {
             case 'application/json':
               if (wrapJson) {
                 err = wrapJson({code, message}, null, req.rid);
@@ -367,11 +367,15 @@ class Application extends BaseApp {
         middlewareConfigList = [middlewareConfigList];
       } else {
         let tmp = [];
-        Object.keys(middlewareConfigList).forEach(function (key) {
-          let midCfg = middlewareConfigList[key];
-          midCfg.id = key;
-          tmp.push(midCfg);
-        });
+        try {
+          utils.sortObjectByKey(middlewareConfigList).forEach(function (key) {
+            let midCfg = middlewareConfigList[key];
+            midCfg.id = key;
+            tmp.push(midCfg);
+          });
+        } catch (e) {
+          return this.exit('loadMiddleware has error:' + e.message);
+        }
         middlewareConfigList = tmp;
       }
     }
@@ -402,7 +406,13 @@ class Application extends BaseApp {
       }
       this.plugins.middleware[midConfig.id] = midConfig;
     });
+    try {
+      this.plugins.middleware = utils.sortConfigByKey(this.plugins.middleware);
+    } catch (e) {
+      this.exit('loadMiddleware has error:' + e.message);
+    }
   }
+
   /**
    * 根据 mid 禁用 middleware
    * @param  {String} mid
@@ -432,10 +442,10 @@ class Application extends BaseApp {
     if (!middleware.id) {
       this.exit('insertMiddlewareBefore(), param `middleware` should have property id');
     }
+    this.loadMiddleware(middleware);
     if (!this.options.orderedMiddleware) {
       this.options.orderedMiddleware = Object.keys(this.plugins.middleware);
     }
-    this.loadMiddleware(middleware);
     this.options.orderedMiddleware.forEach(function (n, i, a) {
       if (n === mid) {
         a.splice(i, 0, middleware.id);
@@ -461,12 +471,16 @@ class Application extends BaseApp {
 
     if (typeof obj === 'object') {
       if (!obj.id || !obj.module) {
-        let tmp = Object.keys(obj);
-        tmp.forEach(function (key) {
-          let ext = obj[key];
-          ext.id = key;
-          extList.push(ext);
-        });
+        try {
+          let tmp = utils.sortObjectByKey(obj);
+          tmp.forEach(function (key) {
+            let ext = obj[key];
+            ext.id = key;
+            extList.push(ext);
+          });
+        } catch (e) {
+          return this.exit('loadExtension has error:' + e.message);
+        }
       } else {
         extList.push(obj);
       }
@@ -610,7 +624,7 @@ class Application extends BaseApp {
             if (!ins.match) {
               ins.match = function truth() {
                 return true;
-              }
+              };
             }
           });
           if (newMidConfig.match) {
@@ -632,7 +646,7 @@ class Application extends BaseApp {
           self.log.warn('[hc-bee]: no middleware matched in ' + midConfig.id);
           next();
           // return res.status(400).send('not auth middleware matched.').end();;
-        };
+        }
         // make combine middleware can be combined.
         combineMiddleware.match = function (req) {
           for (let i = 0; i < subMids.length; i++) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const co = require('co');
 const _ = require('lodash');
+const Topo = require('topo');
 const debug = require('debug')('hc-bee');
 const colors = {
   BLUE: 36,
@@ -11,6 +12,53 @@ const colors = {
   YELLOW: 33,
   RED: 31,
   DRED: 35
+};
+
+/**
+ * Sort Object or Array by deps key(default .deps), fallback to original key order
+ * @param {Object|Array} target The target Object|Array to be sorted
+ * @returns {Array} Array of string|number, sorted keys in target
+ */
+function sortObjectByKey(target) {
+  if (!target) return [];
+  const arr = Array.isArray(target) ?
+    target.map((object, index) => ({key: index, index, object: object || {}})) :
+    Object.keys(target).map((key, index) => ({key, index, object: target[key] || {}}));
+  // sort by topo
+  const topo = new Topo();
+  let allDeps = arr.reduce((acc, x) => acc.concat(x.object.deps), []);
+  const hasDeps = (item) => {
+    if (item.object.deps != null) return true;
+    return allDeps.some(x => x == item.group);
+  };
+  arr.forEach((item, i) => {
+    let object = item.object;
+    item.group = object.id || item.key;
+    if (i > 0 && !hasDeps(item)) {
+      allDeps.push(item.after = arr[i - 1].group);
+    } else {
+      item.after = item.object.deps;
+    }
+    topo.add(item.key, item);
+  });
+  return topo.nodes;
+}
+exports.sortObjectByKey = sortObjectByKey;
+
+/**
+ * Sort config by deps key and return sorted result
+ * @param {Array|Object} target the target to be sorted
+ * @returns {Array|Object} the sorted result
+ */
+exports.sortConfigByKey = function (target) {
+  const isArray = Array.isArray(target);
+  const result = isArray ? [] : {};
+  sortObjectByKey(target).forEach((key) => {
+    isArray ?
+      result.push(target[key]) :
+      result[key] = target[key];
+  });
+  return result;
 };
 
 /**
@@ -124,7 +172,7 @@ exports.wrapController = function (fn) {
     } else {
       return function (req, res, next) {
         Promise.resolve(fn(req, res, next)).catch(next);
-      }
+      };
     }
   } else {
     throw new Error('unknow type of function, ' + fn.toString());
@@ -220,15 +268,15 @@ exports.code = {
 };
 
 exports.map = {
-  'UNAUTHORIZED': 401,
+  UNAUTHORIZED: 401,
   'NOT FOUND': 404,
-  'FORBIDDEN': 403,
-  'ERROR': 500,
-  'URIERROR': 400, // URI 不合法
-  'PAYLOADTOOLARGEERROR': 413 // 实体太大
+  FORBIDDEN: 403,
+  ERROR: 500,
+  URIERROR: 400, // URI 不合法
+  PAYLOADTOOLARGEERROR: 413 // 实体太大
 };
 
-exports.checkForDeadlocks = function(middlewareMap) {
+exports.checkForDeadlocks = function (middlewareMap) {
   const middlewares = Object.keys(middlewareMap).map(mid => (middlewareMap[mid]));
   // Kahn's algorithm, Topological Sorting.
   // https://en.wikipedia.org/wiki/Topological_sorting#Kahn.27s_algorithm
@@ -274,4 +322,4 @@ exports.checkForDeadlocks = function(middlewareMap) {
   if (remainMids.length) {
     throw new Error('[hc-bee]: middlewares contain deadlock, mids: ' + remainMids.join(', '));
   }
-}
+};

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "litelog": "3.0.4",
     "lodash": "4.17.5",
     "minimatch": "3.0.4",
+    "topo": "^3.0.3",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hc-bee",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "description": "the honeycomb app framework based on express",
   "main": "index.js",
   "scripts": {

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -5,6 +5,132 @@ const debug = require('debug')('hc-bee');
 const assert = require('power-assert');
 
 describe('utils test', function () {
+  describe('sortObjectByKey', function () {
+    it('should not throw', () => {
+      assert.doesNotThrow(() => {
+        utils.sortObjectByKey(null);
+        utils.sortObjectByKey();
+        utils.sortObjectByKey('');
+      });
+    });
+    it('should throw', () => {
+      var loopedDeps = {
+        a: {deps: 'c'},
+        b: {deps: 'd'},
+        c: {deps: 'a'}
+      };
+      try {
+        utils.sortObjectByKey(loopedDeps);
+      } catch (e) {
+        assert.equal(e.code, 'ERR_ASSERTION');
+        assert.equal(e.message, 'item added into group c created a dependencies error');
+      }
+    });
+    it('sort object with non-exits deps', () => {
+      var a = {x: {deps: ['d', 'z']}, y: '', z: {deps: ['non-exists']}, a: {}, b: {}, c: 1, d: null};
+      assert.deepStrictEqual(utils.sortObjectByKey(a), ['z', 'a', 'b', 'c', 'd', 'x', 'y']);
+    });
+    it('sort array', () => {
+      var noChange = [{}, {}, {}, {}, {}, {}];
+      assert.deepStrictEqual(utils.sortObjectByKey(noChange), [0, 1, 2, 3, 4, 5]);
+      var b = [{deps: [6]}, {deps: 2}, {}, 2, '', 0, NaN];
+      assert.deepStrictEqual(utils.sortObjectByKey(b), [2, 1, 3, 4, 5, 6, 0]);
+    });
+    it('sort object by topo', () => {
+      var noChange = {
+        x: {},
+        y: {},
+        z: {},
+        a: {},
+        b: {},
+        c: 1,
+        d: null
+      };
+      assert.deepStrictEqual(utils.sortObjectByKey(noChange), Object.keys(noChange));
+      var a = {
+        x: {deps: 'y'},
+        y: {deps: 'a'},
+        z: {},
+        a: {},
+        b: {},
+        c: 1,
+        d: null
+      };
+      assert.deepStrictEqual(utils.sortObjectByKey(a), ['a', 'y', 'x', 'z', 'b', 'c', 'd']);
+      var b = {
+        x: {deps: ['c', 'y']},
+        y: {deps: 'abc'},
+        z: {id: 'abc'},
+        a: {},
+        b: {deps: 'd'},
+        c: {deps: 'a'},
+        d: {},
+      };
+      assert.deepStrictEqual(utils.sortObjectByKey(b), ['z', 'y', 'a', 'c', 'x', 'd', 'b']);
+    });
+  });
+  describe('sortConfigByKey', () => {
+    it('normal', () => {
+      var originConfig = {
+        x: {deps: 'z'},
+        y: {},
+        z: {}
+      };
+      var origin = utils.sortConfigByKey(originConfig);
+      assert.deepStrictEqual(origin, {z: {}, x: {deps: 'z'}, y: {}});
+    });
+    it('has deps loop', () => {
+      var called = false;
+      var originConfig = {
+        x: {deps: 'z'},
+        y: {},
+        z: {deps: 'x'}
+      };
+      try {
+        utils.sortConfigByKey(originConfig);
+      } catch (e) {
+        called = true;
+        assert.deepStrictEqual(e.message, 'item added into group z created a dependencies error');
+      }
+      assert.equal(called, true);
+    });
+    it('merge exist', () => {
+      var originConfig = {
+        x: {deps: ['z', 'b']},
+        y: {},
+        z: {}
+      };
+      var origin = utils.sortConfigByKey(originConfig);
+      assert.deepStrictEqual(origin, {
+        z: {},
+        x: {deps: ['z', 'b']},
+        y: {}
+      });
+      var added = utils.sortConfigByKey({
+        a: {deps: ['y', 'd']},
+        b: {deps: 'c'},
+        c: {},
+        d: {}
+      });
+      assert.deepStrictEqual(added, {
+        c: {},
+        b: {deps: 'c'},
+        d: {},
+        a: {deps: ['y',
+          'd']}
+      });
+      Object.assign(origin, added);
+      assert.deepStrictEqual(utils.sortConfigByKey(origin), {
+        z: {},
+        y: {},
+        c: {},
+        b: {deps: 'c'},
+        x: {deps: ['z', 'b']},
+        d: {},
+        a: {deps: ['y', 'd']}
+      });
+    });
+  });
   describe('deadlock check', function () {
     it('normal middleware should have no error.', function () {
       utils.checkForDeadlocks({
@@ -44,7 +170,7 @@ describe('utils test', function () {
             module: ['a']
           }
         });
-      } catch(e) {
+      } catch (e) {
         assert.equal(e.message, '[hc-bee]: middlewares contain deadlock, mids: a');
       }
     });
@@ -64,7 +190,7 @@ describe('utils test', function () {
             id: 'c'
           }
         });
-      } catch(e) {
+      } catch (e) {
         assert.equal(e.message, '[hc-bee]: middlewares contain deadlock, mids: a, b');
       }
     });
@@ -85,7 +211,7 @@ describe('utils test', function () {
             module: ['a']
           }
         });
-      } catch(e) {
+      } catch (e) {
         assert.equal(e.message, '[hc-bee]: middlewares contain deadlock, mids: a, b, c');
       }
     });

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const should = require('should'); // eslint-disable-line
+
+describe('order.test.js', () => {
+  const app = require('./orderEnv').app;
+  describe('test config oerder', () => {
+    it('should middleware order fine', () => {
+      should(Object.keys(app.plugins.middleware))
+        .deepEqual([
+          'custumMid2',
+          'static',
+          'custumMid3',
+          'customMid4',
+          'customMid5',
+          'customMid6',
+          'custumMid1',
+          'cors',
+          'timeout',
+          'referer',
+          'cookieParser',
+          'cookieSession',
+          'bodyParser',
+          'csrf',
+          'log',
+          'custumMid0'
+        ]);
+    });
+    it('should extension order fine', () => {
+      should(Object.keys(app.plugins.extension))
+        .deepEqual([
+          'timer',
+          'customExt1',
+          'redirect'
+        ]);
+    });
+  });
+});

--- a/test/orderEnv.js
+++ b/test/orderEnv.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+process.env.HC_APP_CONFIG = JSON.stringify({
+  serverRoot: './',
+  appRoot: path.join(__dirname, './orderExample')
+});
+
+const app = require(path.join(__dirname, './orderExample/app'));
+
+app.ready(true);
+
+exports.app = app;

--- a/test/orderExample/app.js
+++ b/test/orderExample/app.js
@@ -1,0 +1,11 @@
+'use strict';
+/**
+ * this file is app enter
+ */
+const Honeybee = require('../../');
+const log = require('../../log');
+const app = new Honeybee();
+
+app.ready(true);
+
+module.exports = app;

--- a/test/orderExample/config/config.js
+++ b/test/orderExample/config/config.js
@@ -1,0 +1,63 @@
+'use strict';
+console.log(2341234)
+
+module.exports = {
+  middleware: {
+    cors: {
+      deps: ['id_customMid6', 'custumMid1']
+    },
+    static: {
+      deps: 'custumMid2'
+    },
+    cookieSession: {
+      config: {
+        secret: 'hello_the_world'
+      }
+    },
+    custumMid0: {
+      enable: true,
+      module: '../middleware/mid0'
+    },
+    custumMid1: {
+      enable: true,
+      deps: 'id_customMid6',
+      module: '../middleware/mid1'
+    },
+    custumMid2: {
+      enable: true,
+      module: '../middleware/mid2'
+    },
+    custumMid3: {
+      enable: true,
+      module: '../middleware/mid3',
+      config: {}
+    },
+    customMid4: {
+      enable: true,
+      module: '../middleware/mid4',
+      config: {}
+    },
+    customMid5: {
+      enable: true,
+      module: '../middleware/mid5',
+      config: {
+        overwrite: 'mid5Config'
+      }
+    },
+    customMid6: {
+      id: 'id_customMid6',
+      enable: true,
+      module: '../middleware/mid6',
+      config: {}
+    },
+  },
+  extension: {
+    redirect: {
+      deps: 'customExt1'
+    },
+    customExt1: {
+      enable: true,
+      deps: 'timer'
+    }
+  }
+};

--- a/test/orderExample/config/index.js
+++ b/test/orderExample/config/index.js
@@ -1,0 +1,19 @@
+'use strict';
+const _ = require('lodash');
+const path = require('path');
+
+let config = {
+  middleware: {}
+};
+
+
+try {
+  let envConfig = require('./config');
+  config = _.merge(config, envConfig);
+} catch (e) {
+  if (e.code !== 'MODULE_NOT_FOUND') {
+    console.log('[ERROR] base framework loading config/config.js error', e.message); // eslint-disable-line
+  }
+}
+
+module.exports = config;

--- a/test/orderExample/middleware/mid0.js
+++ b/test/orderExample/middleware/mid0.js
@@ -1,0 +1,1 @@
+module.exports = () => {return (req, res, next) => {next()}}

--- a/test/orderExample/middleware/mid1.js
+++ b/test/orderExample/middleware/mid1.js
@@ -1,0 +1,1 @@
+module.exports = (req, res, next) => {next()};

--- a/test/orderExample/middleware/mid2.js
+++ b/test/orderExample/middleware/mid2.js
@@ -1,0 +1,1 @@
+module.exports = (opt) => {return (req, res, next) => {next()}}

--- a/test/orderExample/middleware/mid3.js
+++ b/test/orderExample/middleware/mid3.js
@@ -1,0 +1,1 @@
+module.exports = (app, opt) => {return (req, res, next) => {next()}};

--- a/test/orderExample/middleware/mid4.js
+++ b/test/orderExample/middleware/mid4.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (opt) => {
+  function Mid4(req, res, next) {
+    res.write(opt.overwrite || 'mid4Default');
+    next();
+  };
+
+  Mid4.match = function (req) {
+    return req.url.indexOf('switchMid=mid4') !== -1;
+  };
+
+  return Mid4;
+};

--- a/test/orderExample/middleware/mid5.js
+++ b/test/orderExample/middleware/mid5.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (opt) => {
+  function Mid5(req, res, next) {
+    res.write(opt.overwrite || 'mid5Default');
+    next();
+  };
+
+  Mid5.match = function (req) {
+    return req.url.indexOf('switchMid=mid5') !== -1;
+  };
+
+  return Mid5;
+};

--- a/test/orderExample/middleware/mid6.js
+++ b/test/orderExample/middleware/mid6.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = (opt) => {
+  function Mid6(req, res, next) {
+    res.write(opt.overwrite || 'mid6Default');
+    next();
+  };
+
+  Mid6.match = function (req) {
+    return req.url.indexOf('switchMid=mid6') !== -1;
+  };
+
+  return Mid6;
+};

--- a/test/orderExample/package.json
+++ b/test/orderExample/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "example",
+    "version": "0.0.1",
+    "description": "an example app base on honeybee",
+    "main": "index.js",
+    "scripts": {},
+    "keywords": [
+      "framework",
+      "express"
+    ],
+    "bin": {},
+    "dependencies": {},
+    "devDependencies": {}
+  }
+  


### PR DESCRIPTION
This PR allow define `deps` between config middleware/extension, usage as below:

```js
//config_default.js
middleware: {
  static: {deps: 'mid1'},
  mid1: {deps: 'mid4'},
  mid2: {deps: ['mid3', 'mid4']},
  mid3: {},
  mid4: {}
}
```

The resulting middleware order as below:
```js
[
    "mid3",
    "mid4",
    "mid1",
    "static",
    "mid2"
]
```

If the config has any dependency loop, the application will exit and show which config item has error.
